### PR TITLE
Use env GTM ID in noscript template

### DIFF
--- a/_includes/patterns/google-tag-manager-no-script.njk
+++ b/_includes/patterns/google-tag-manager-no-script.njk
@@ -1,6 +1,5 @@
     <!-- Google Tag Manager (noscript) -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZ8ZK4C3" height="0" width="0" style="display:none;visibility:hidden">
-      </iframe>
+      <iframe src="https://www.googletagmanager.com/ns.html?id={{ env.gtmId }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
## Summary
- replace hard-coded Google Tag Manager ID with `{{ env.gtmId }}` in noscript iframe

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build-nocolor`


------
https://chatgpt.com/codex/tasks/task_e_688f18e2a098832b9a14d35e35ff9b72