### PR TITLE
Handle quotes in Contentful rich text

### DIFF
--- a/_data/getContentfulArticleSingle.js
+++ b/_data/getContentfulArticleSingle.js
@@ -8,6 +8,7 @@ import client from '../_helpers/contentfulClient.js';
 import parseImageWrapper from '../_helpers/parseImageWrapper.js';
 import parseSeo from '../_helpers/parseSeo.js';
 import cachedFetch from '../_helpers/cache.js';
+import renderRichTextAsHtml from '../_helpers/renderRichTextAsHtml.js';
 
 export default async function getContentfulArticleSingle() {
   // const entryId = process.env.PROMO_ARTICLE_ENTRY_ID;
@@ -25,6 +26,10 @@ export default async function getContentfulArticleSingle() {
     const imageEntry = fields.mainImage || fields.image || null;
     fields.mainImage = parseImageWrapper(imageEntry);
 
+    if (fields.body) {
+      fields.body = renderRichTextAsHtml(fields.body);
+    }
+
     // ✨ Add this block to process SEO for articles/promos ✨
     if (fields.seoMetaData) {
       fields.seoMetaData = parseSeo(fields.seoMetaData);
@@ -38,6 +43,9 @@ export default async function getContentfulArticleSingle() {
         const articleFields = { ...item.fields };
         // This line is for images *within* the deckContent, if it were used.
         articleFields.mainImage = parseImageWrapper(articleFields.mainImage);
+        if (articleFields.body) {
+          articleFields.body = renderRichTextAsHtml(articleFields.body);
+        }
         return { ...articleFields, sys: item.sys };
       }
       return null;

--- a/_data/getContentfulNotes.js
+++ b/_data/getContentfulNotes.js
@@ -4,6 +4,7 @@
 
 import client from '../_helpers/contentfulClient.js';
 import cachedFetch from '../_helpers/cache.js';
+import renderRichTextAsHtml from '../_helpers/renderRichTextAsHtml.js';
 
 export default async function getContentfulNotes() {
   const fetcher = async () => {
@@ -17,7 +18,7 @@ export default async function getContentfulNotes() {
       return {
         noteTitle: fields.noteTitle,
         externalLink: fields.externalLink,
-        authorCommentary: fields.authorCommentary,
+        authorCommentary: fields.authorCommentary ? renderRichTextAsHtml(fields.authorCommentary) : null,
         date: item.sys?.publishedAt || item.sys?.createdAt,
       };
     });

--- a/_helpers/renderRichTextAsHtml.js
+++ b/_helpers/renderRichTextAsHtml.js
@@ -1,0 +1,31 @@
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+import { BLOCKS } from '@contentful/rich-text-types';
+import parseImageWrapper from './parseImageWrapper.js';
+
+export default function renderRichTextAsHtml(json) {
+  const options = {
+    renderNode: {
+      [BLOCKS.EMBEDDED_ENTRY]: (node) => {
+        const entry = node.data.target;
+        if (entry?.sys?.contentType?.sys?.id === 'mediaImageAsset') {
+          const img = parseImageWrapper(entry);
+          if (img) {
+            return `<figure><img src="${img.url}" alt="${img.alt}">${img.caption ? `<figcaption>${img.caption}</figcaption>` : ''}</figure>`;
+          }
+        }
+        return '';
+      },
+      [BLOCKS.EMBEDDED_ASSET]: (node) => {
+        const asset = node.data.target;
+        const url = asset?.fields?.file?.url ? `https:${asset.fields.file.url}` : '';
+        const alt = asset?.fields?.title || '';
+        return url ? `<img src="${url}" alt="${alt}">` : '';
+      },
+      [BLOCKS.QUOTE]: (node, next) => {
+        return `<blockquote class="text-muted-foreground text-base italic border-l-4 border-gray-300 pl-4 mb-4">${next(node.content)}</blockquote>`;
+      },
+    },
+  };
+
+  return documentToHtmlString(json, options);
+}

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -60,7 +60,7 @@ layout: layouts/base.njk
           </a>
           {% if note.authorCommentary %}
           <div class="text-foreground text-sm mb-4">
-            {{ note.authorCommentary | renderRichTextAsHtml | safe }}
+            {{ note.authorCommentary | safe }}
           </div>
           {% endif %}
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,10 +10,7 @@ import { eleventyImageTransformPlugin } from "@11ty/eleventy-img";
 import Image from "@11ty/eleventy-img";
 
 import 'dotenv/config'; // Load environment variables (ESM syntax for dotenv)
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
-import { BLOCKS } from '@contentful/rich-text-types';
-
-import parseImageWrapper from './_helpers/parseImageWrapper.js';
+import renderRichTextAsHtml from './_helpers/renderRichTextAsHtml.js';
 
 import fs from 'fs';
 import path from 'path';
@@ -78,29 +75,7 @@ export default async function(eleventyConfig) {
 	// });
 
         // Add a filter to render Contentful rich text to HTML
-        eleventyConfig.addFilter("renderRichTextAsHtml", (json) => {
-                const options = {
-                        renderNode: {
-                                [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-                                        const entry = node.data.target;
-                                        if (entry?.sys?.contentType?.sys?.id === 'mediaImageAsset') {
-                                                const img = parseImageWrapper(entry);
-                                                if (img) {
-                                                        return `<figure><img src="${img.url}" alt="${img.alt}">${img.caption ? `<figcaption>${img.caption}</figcaption>` : ''}</figure>`;
-                                                }
-                                        }
-                                        return '';
-                                },
-                                [BLOCKS.EMBEDDED_ASSET]: (node) => {
-                                        const asset = node.data.target;
-                                        const url = asset?.fields?.file?.url ? `https:${asset.fields.file.url}` : '';
-                                        const alt = asset?.fields?.title || '';
-                                        return url ? `<img src="${url}" alt="${alt}">` : '';
-                                },
-                        }
-                };
-                return documentToHtmlString(json, options);
-        });
+        eleventyConfig.addFilter("renderRichTextAsHtml", renderRichTextAsHtml);
 
 	// In eleventy.config.js, inside the `export default async function(eleventyConfig) { ... }` function
 


### PR DESCRIPTION
## Summary
- Centralize Contentful rich-text rendering with a reusable helper
- Support styled block quotes via `BLOCKS.QUOTE`
- Pre-render Contentful article bodies and note commentary to HTML

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1537adeec832ba44aab883092f76f