### PR TITLE
Use datePublished for notes and home layout

### DIFF
--- a/_data/getContentfulNotes.js
+++ b/_data/getContentfulNotes.js
@@ -9,7 +9,7 @@ export default async function getContentfulNotes() {
   const fetcher = async () => {
     const entries = await client.getEntries({
       content_type: 'composeNote',
-      order: '-sys.publishedAt',
+      order: '-fields.datePublished',
     });
 
     return entries.items.map(item => {
@@ -18,7 +18,7 @@ export default async function getContentfulNotes() {
         noteTitle: fields.noteTitle,
         externalLink: fields.externalLink,
         authorCommentary: fields.authorCommentary,
-        date: item.sys?.publishedAt || item.sys?.createdAt,
+        datePublished: fields.datePublished || item.sys?.publishedAt || item.sys?.createdAt,
       };
     });
   };

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -64,9 +64,9 @@ layout: layouts/base.njk
           </div>
           {% endif %}
 
-          {% if note.date %}
+          {% if note.datePublished %}
           <div class="text-muted-foreground text-xs">
-            <span>{{ note.date | readableDate }}</span>
+            <span>{{ note.datePublished | readableDate }}</span>
           </div>
           {% endif %}
         </article>


### PR DESCRIPTION
## Summary
- query composeNote entries ordered by `datePublished`
- expose and display `datePublished` for notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing Contentful credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a1542165cc832b982963766ee8a0c4