### PR TITLE
refactor: update setlists data paths for live shows

### DIFF
--- a/_data/setlists/attended/index.js
+++ b/_data/setlists/attended/index.js
@@ -1,0 +1,2 @@
+import index from '../../setlists.attended.index.json' with { type: 'json' };
+export default index;

--- a/_data/setlists/views.js
+++ b/_data/setlists/views.js
@@ -1,0 +1,2 @@
+import views from '../setlists.views.json' with { type: 'json' };
+export default views;

--- a/content/currently/listening.njk
+++ b/content/currently/listening.njk
@@ -54,12 +54,12 @@
 
             <section class="mt-16">
 
-                {# _data/setlists.views.json -> setlists_views #}
+                {# _data/setlists/views.json -> setlists.views, _data/setlists/attended/index.json -> setlists.attended.index #}
                 <h1>Live shows</h1>
                 <p>Marked as attended on <a href="https://www.setlist.fm/">setlist.fm</a></p>
 
-                {% set byYear = setlists_views and setlists_views.byYear %}
-                {% set index = setlists_attended_index and setlists_attended_index.items %}
+                {% set byYear = setlists.views and setlists.views.byYear %}
+                {% set index = setlists.attended.index and setlists.attended.index.items %}
 
                 {% if byYear and index %}
                 {# dictsort returns [key, value] pairs; reverse to get newest year first #}


### PR DESCRIPTION
## Summary
- use nested `setlists.views` and `setlists.attended.index` data paths in listening page
- add proxies exposing existing JSON under new `_data/setlists` structure

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b248aa973c832b849c6ca0a4bf1a19