### PR TITLE
feat: render embedded video assets

### DIFF
--- a/_helpers/parseVideoWrapper.js
+++ b/_helpers/parseVideoWrapper.js
@@ -1,0 +1,17 @@
+export default function parseVideoWrapper(wrapper) {
+  if (!wrapper || !wrapper.fields) {
+    return null;
+  }
+
+  const { videoUrl, videoTitle, videoCaption } = wrapper.fields;
+
+  if (!videoUrl) {
+    return null;
+  }
+
+  return {
+    url: videoUrl,
+    title: videoTitle || '',
+    caption: videoCaption || null,
+  };
+}

--- a/_helpers/renderRichTextAsHtml.js
+++ b/_helpers/renderRichTextAsHtml.js
@@ -7,6 +7,7 @@
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { BLOCKS } from '@contentful/rich-text-types';
 import parseImageWrapper from './parseImageWrapper.js';
+import parseVideoWrapper from './parseVideoWrapper.js';
 
 export default function renderRichTextAsHtml(json) {
   const options = {
@@ -17,6 +18,12 @@ export default function renderRichTextAsHtml(json) {
           const img = parseImageWrapper(entry);
           if (img) {
             return `<figure><img src="${img.url}" alt="${img.alt}">${img.caption ? `<figcaption>${img.caption}</figcaption>` : ''}</figure>`;
+          }
+        }
+        if (entry?.sys?.contentType?.sys?.id === 'mediaVideoAsset') {
+          const video = parseVideoWrapper(entry);
+          if (video) {
+            return `<figure><iframe src="${video.url}" title="${video.title}" allowfullscreen></iframe>${video.caption ? `<figcaption>${video.caption}</figcaption>` : ''}</figure>`;
           }
         }
         return '';


### PR DESCRIPTION
## Summary
- parse `mediaVideoAsset` entries to extract url, title and caption
- render rich text video entries as a figure with iframe and optional figcaption

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_68b3ced1ec2c832b8b6a5639fa3f041d