### PR TITLE
Use shared Rich Text renderer for notes

### DIFF
--- a/_data/getContentfulNotes.js
+++ b/_data/getContentfulNotes.js
@@ -5,9 +5,6 @@
 import client from '../_helpers/contentfulClient.js';
 import renderRichTextAsHtml from '../_helpers/renderRichTextAsHtml.js';
 import cachedFetch from '../_helpers/cache.js';
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
-import { BLOCKS } from '@contentful/rich-text-types';
-import parseImageWrapper from '../_helpers/parseImageWrapper.js'; 
 
 export default async function getContentfulNotes() {
   const fetcher = async () => {
@@ -21,35 +18,11 @@ export default async function getContentfulNotes() {
       order: '-fields.datePublished',
     });
 
-    const options = {
-      renderNode: {
-        [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-          const entry = node.data.target;
-          if (entry?.sys?.contentType?.sys?.id === 'mediaImageAsset') {
-            const img = parseImageWrapper(entry);
-            if (img) {
-              return `<figure><img src="${img.url}" alt="${img.alt}">${img.caption ? `<figcaption>${img.caption}</figcaption>` : ''}</figure>`;
-            }
-          }
-          return '';
-        },
-        [BLOCKS.EMBEDDED_ASSET]: (node) => {
-          const asset = node.data.target;
-          const url = asset?.fields?.file?.url ? `https:${asset.fields.file.url}` : '';
-          const alt = asset?.fields?.title || '';
-          return url ? `<img src="${url}" alt="${alt}">` : '';
-        },
-      },
-    };
-
     return entries.items.map(item => {
       const fields = item.fields || {};
-      const authorCommentaryHtml = fields.authorCommentary
-        ? documentToHtmlString(fields.authorCommentary, options)
-        : null;
       return {
         noteTitle: fields.noteTitle,
-        externalLink: fields.externalLink,  
+        externalLink: fields.externalLink,
         authorCommentary: fields.authorCommentary ? renderRichTextAsHtml(fields.authorCommentary) : null,
         datePublished: fields.datePublished || item.sys?.publishedAt || item.sys?.createdAt,
       };


### PR DESCRIPTION
## Summary
- Remove bespoke rich-text rendering from `getContentfulNotes`
- Rely on `renderRichTextAsHtml` which includes video and image handling

## Testing
- `node - <<'NODE' import renderRichTextAsHtml from './_helpers/renderRichTextAsHtml.js';

const doc = {
  nodeType: 'document',
  data: {},
  content: [
    {
      nodeType: 'embedded-entry-block',
      data: {
        target: {
          sys: { contentType: { sys: { id: 'mediaVideoAsset' } } },
          fields: {
            videoUrl: 'https://example.com/video',
            videoTitle: 'Example Video',
            videoCaption: 'Sample caption'
          }
        }
      },
      content: []
    }
  ]
};

console.log(renderRichTextAsHtml(doc));
NODE`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3cf8df314832b890b7b9aa719f989