### PR TITLE
Add permanent pages for notes

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -52,11 +52,8 @@ layout: layouts/base.njk
     <div class="grid grid-cols-1 gap-8">
       {% for note in notesDeck %}
         <article class="p-6 border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300">
-          <a href="{{ note.externalLink }}" target="_blank" rel="noopener noreferrer" class="block no-underline hover:underline underline-offset-2">
-            <h3 class="font-serif text-xl font-medium mb-2">
-              {{ note.noteTitle }}
-              <svg xmlns="http://www.w3.org/2000/svg" class="inline-block ml-2 w-4 h-4 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-            </h3>
+          <a href="/notes/{{ note.datePublished | htmlDateString }}-{{ note.noteTitle | slug }}/" class="block no-underline hover:underline underline-offset-2">
+            <h3 class="font-serif text-xl font-medium mb-2">{{ note.noteTitle }}</h3>
           </a>
           {% if note.authorCommentary %}
           <div class="text-foreground text-sm mb-4">
@@ -74,7 +71,7 @@ layout: layouts/base.njk
         </article>
       {% endfor %}
     </div>
-    
+
     <!-- Uncomment this section if you want to add a "View All Notes" link
     <div class="mt-12 text-center">
       <a href="/notes/" class="group inline-flex items-center text-sm font-medium tracking-wider uppercase text-vividcrimson">

--- a/content/notes.njk
+++ b/content/notes.njk
@@ -17,6 +17,7 @@
 }
 ---
 
+{% set notesDeck = getContentfulNotes %}
 
 {# Section for Notes, links, and emphemera #}
 <section class="py-6 bg-white">
@@ -26,11 +27,8 @@
     <div class="grid grid-cols-1 gap-8">
       {% for note in notesDeck %}
         <article class="p-6 border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-300">
-          <a href="{{ note.externalLink }}" target="_blank" rel="noopener noreferrer" class="block no-underline hover:underline underline-offset-2">
-            <h3 class="font-serif text-xl font-medium mb-2">
-              {{ note.noteTitle }}
-              <svg xmlns="http://www.w3.org/2000/svg" class="inline-block ml-2 w-4 h-4 text-black" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-            </h3>
+          <a href="/notes/{{ note.datePublished | htmlDateString }}-{{ note.noteTitle | slug }}/" class="block no-underline hover:underline underline-offset-2">
+            <h3 class="font-serif text-xl font-medium mb-2">{{ note.noteTitle }}</h3>
           </a>
           {% if note.authorCommentary %}
           <div class="text-foreground text-sm mb-4">

--- a/content/notes/note.njk
+++ b/content/notes/note.njk
@@ -1,0 +1,36 @@
+---js
+{
+  pagination: {
+    data: "getContentfulNotes",
+    size: 1,
+    alias: "note",
+  },
+  layout: "layouts/base.njk",
+  eleventyComputed: {
+    permalink: (data) => {
+      if (data.note && data.note.noteTitle && data.note.datePublished) {
+        const slug = String(data.note.noteTitle)
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '');
+        const datePart = new Date(data.note.datePublished).toISOString().split('T')[0];
+        return `/notes/${datePart}-${slug}/index.html`;
+      }
+      return false;
+    },
+  },
+  tags: ["notes"],
+}
+---
+<article class="w-full max-w-3xl mx-auto">
+  <h1 class="font-serif text-3xl font-medium mb-4">{{ note.noteTitle }}</h1>
+  {% if note.authorCommentary %}
+  <div class="prose mb-4">{{ note.authorCommentary | safe }}</div>
+  {% endif %}
+  {% if note.externalLink %}
+  <p class="mb-4"><a href="{{ note.externalLink }}" target="_blank" rel="noopener noreferrer" class="underline">Visit link ↗</a></p>
+  {% endif %}
+  {% if note.datePublished %}
+  <p class="text-muted-foreground text-xs">Published on <time datetime="{{ note.datePublished | htmlDateString }}">{{ note.datePublished | readableDate }}</time></p>
+  {% endif %}
+</article>


### PR DESCRIPTION
## Summary
- create paginated template for Contentful notes with date-and-title permalinks
- link notes from listing and home page to their permanent URLs

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ⚠️ `npm run build` (Missing Contentful credentials)


------
https://chatgpt.com/codex/tasks/task_e_68b3ec081ca0832bad4b0ff0d7967724